### PR TITLE
switch to supplying client on creation of variants

### DIFF
--- a/src/ImageLibrary.js
+++ b/src/ImageLibrary.js
@@ -51,21 +51,27 @@ class ImageLibrary extends Component {
   }
 
   onCreateImage = async (values) => {
-    values['client'] = this.props.client
-    this.api.createImage(values)
-      .then((image) => {
-        let all = this.state.images
-        all = all.concat(image)
-        this.setState({
-          images: all,
-          mode: 'list',
-        })
-      })
+    let image = await this.api.createImage(values)
+    let preview = await this.api.createVariant(image, {
+      width: 150,
+      height: 150,
+      format: 'jpeg',
+      name: 'preview',
+      client: 'image_library'
+    })
+    image.variants = [preview]
+    let all = this.state.images
+    all = all.concat(image)
+    this.setState({
+      images: all,
+      mode: 'list',
+    })
   }
 
 
   onCreateVariant = async (format) => {
-    this.api.createVariant(this.state.selectedImage, format)
+    const formatForClient = Object.assign({}, format, { client: this.props.client })
+    this.api.createVariant(this.state.selectedImage, formatForClient)
       .then((variant) => {
         let toUpdate = this.state.images.find(img => img.id === this.state.selectedImage.id)
         let vars = toUpdate.variants
@@ -170,6 +176,7 @@ class ImageLibrary extends Component {
         renderable =  <div className='image-view'>
                         <Image
                           image={this.state.selectedImage}
+                          client={this.props.client}
                           onShow={this.onShowImage}
                           onEdit={this.onEditImage}
                           onDelete={this.onDeleteImage}

--- a/src/ImageLibrary.js
+++ b/src/ImageLibrary.js
@@ -55,9 +55,10 @@ class ImageLibrary extends Component {
     let preview = await this.api.createVariant(image, {
       width: 150,
       height: 150,
+      mode: 'fit',
       format: 'jpeg',
       name: 'preview',
-      client: 'image_library'
+      client: '_internal'
     })
     image.variants = [preview]
     let all = this.state.images
@@ -70,7 +71,10 @@ class ImageLibrary extends Component {
 
 
   onCreateVariant = async (format) => {
-    const formatForClient = Object.assign({}, format, { client: this.props.client })
+    // NOTE: Unless format specifies `mode` we default to crop images to given format dimensions.
+    // This has to be explicit here, as the API default is resize to `fit`.
+    // NOTE: In any case we override any (mistakenly) set client.
+    const formatForClient = Object.assign({ mode: 'fill' }, format, { client: this.props.client }) 
     this.api.createVariant(this.state.selectedImage, formatForClient)
       .then((variant) => {
         let toUpdate = this.state.images.find(img => img.id === this.state.selectedImage.id)

--- a/src/ImageLibraryAdmin.js
+++ b/src/ImageLibraryAdmin.js
@@ -63,7 +63,7 @@ class ImageLibraryAdmin extends Component {
     return(
       <div className='image-library-admin'>
         <div className='form-group p-3'>
-          <label className='label'>What client you want?</label>
+          <label className='label'>As which client do you want to masquerade?</label>
           <select
             name='client'
             onChange={(evt) => this.onSelectClient(evt.target.value)}

--- a/src/ImageLibraryAdmin.test.js
+++ b/src/ImageLibraryAdmin.test.js
@@ -13,7 +13,7 @@ test('renders ImageLibaryAdmin', () => {
       token={'123456'}/>
   )
 
-  const ele = getByText(/What client/i)
+  const ele = getByText(/As which client/i)
   expect(ele).toBeInTheDocument
 })
 

--- a/src/api.js
+++ b/src/api.js
@@ -10,11 +10,7 @@ class Api {
   }
 
   makeImagesUrl = () => {
-    if (this.client) {
-      return this.host + imagesUrl + '?client=' + this.client
-    } else {
-      return this.host + imagesUrl
-    }
+    return this.host + imagesUrl
   }
 
   getClientsUrl = () => {

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -4,21 +4,36 @@ import VariantList from './VariantList'
 import ReactMarkdown from 'react-markdown'
 
 const Image = (props) => {
-
-  const variantNames = props.image.variants.map(v => v.name)
+  const clientVariants = props.image.variants.filter(v => v.client === props.client)
+  const otherClientsWithVariants = props.image.variants.filter(v => !['image_library', props.client].includes(v.client)).map(v => v.client)
+  const variantNames = clientVariants.map(v => v.name)
 
   const variantActions = props.formats.map((f, k)=> {
     if (!variantNames.includes(f.name)) {
       return(
         <button key={k}
-          onClick={() => props.onCreateVariant(f)}
-          className='btn btn-outline-light mr-2 mb-3'>
+                onClick={() => props.onCreateVariant(f)}
+                className='btn btn-outline-light mr-2 mb-3'>
           Create '{f.name}'
         </button>
       )
     }
     return ""
   })
+
+  const otherClientsList = otherClientsWithVariants.map((c) =>
+    (<><span className='badge badge-info'>{c}</span><span>&nbsp;</span></>)
+  )
+
+  let variantList = (
+    <React.Fragment>
+      <p>No Variant available</p>
+    </React.Fragment>
+  )
+
+  if (clientVariants.length > 0) {
+    variantList = (<VariantList variants={clientVariants} onDeleteVariant={props.onDeleteVariant}/>)
+  }
 
   return(
     <React.Fragment>
@@ -39,19 +54,20 @@ const Image = (props) => {
       <div className='mb-3'>
         <h3>Variants</h3>
         {variantActions}
-        <VariantList variants={props.image.variants} onDeleteVariant={props.onDeleteVariant}/>
+        {variantList}
+        <strong>Has variants for these clients</strong> {otherClientsList}
       </div>
       <div className='mb-3'>
-      <button
-        onClick={() => props.onEdit(props.image)}
-        className='btn btn-outline-warning mr-3'>
-        Edit
-      </button>
-      <button
-        onClick={() => props.onDelete(props.image.id)}
-        className='btn btn-outline-danger'>
-        Delete
-      </button>
+        <button
+          onClick={() => props.onEdit(props.image)}
+          className='btn btn-outline-warning mr-3'>
+          Edit
+        </button>
+        <button
+          onClick={() => props.onDelete(props.image.id)}
+          className='btn btn-outline-danger'>
+          Delete
+        </button>
       </div>
       <img src={props.image.url} alt={props.image.alt} className='img img-fluid'/>
     </React.Fragment>
@@ -60,6 +76,7 @@ const Image = (props) => {
 
 Image.propTypes = {
   image: PropTypes.object.isRequired,
+  client: PropTypes.string.isRequired,
   formats: PropTypes.array.isRequired,
   onCreateVariant: PropTypes.func.isRequired,
   onDeleteVariant: PropTypes.func.isRequired,

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -5,7 +5,6 @@ import ReactMarkdown from 'react-markdown'
 
 const Image = (props) => {
   const clientVariants = props.image.variants.filter(v => v.client === props.client)
-  const otherClientsWithVariants = props.image.variants.filter(v => !['image_library', props.client].includes(v.client)).map(v => v.client)
   const variantNames = clientVariants.map(v => v.name)
 
   const variantActions = props.formats.map((f, k)=> {
@@ -21,9 +20,12 @@ const Image = (props) => {
     return ""
   })
 
-  const otherClientsList = otherClientsWithVariants.map((c) =>
-    (<><span className='badge badge-info'>{c}</span><span>&nbsp;</span></>)
-  )
+  const variantMap = {}
+  props.image.variants.forEach(v => {
+    variantMap[v.client] = v
+  })
+  const clients = Object.keys(variantMap).filter(c => c !== '_internal')
+
 
   let variantList = (
     <React.Fragment>
@@ -45,7 +47,18 @@ const Image = (props) => {
             Width: {props.image.width} <br />
             Height: {props.image.height} <br />
             Alt: {props.image.alt}<br />
+            Used by: {clients.join(', ')}
           </p>
+          <button
+            onClick={() => props.onEdit(props.image)}
+            className='btn btn-outline-warning mr-3'>
+            Edit
+          </button>
+          <button
+            onClick={() => props.onDelete(props.image.id)}
+            className='btn btn-outline-danger'>
+            Delete
+          </button>
         </div>
         <div className='col-md-9'>
           <ReactMarkdown source={props.image.notes} />
@@ -55,20 +68,8 @@ const Image = (props) => {
         <h3>Variants</h3>
         {variantActions}
         {variantList}
-        <strong>Has variants for these clients</strong> {otherClientsList}
       </div>
-      <div className='mb-3'>
-        <button
-          onClick={() => props.onEdit(props.image)}
-          className='btn btn-outline-warning mr-3'>
-          Edit
-        </button>
-        <button
-          onClick={() => props.onDelete(props.image.id)}
-          className='btn btn-outline-danger'>
-          Delete
-        </button>
-      </div>
+      <h3 className='mb-3'>Original uploaded Image</h3>
       <img src={props.image.url} alt={props.image.alt} className='img img-fluid'/>
     </React.Fragment>
   )

--- a/src/components/Image.test.js
+++ b/src/components/Image.test.js
@@ -11,9 +11,10 @@ test('renders Image', () => {
     url: "http://example.com/img/1.jpg",
     variants: [],
   }
-  const {getAllByText} = render(
+  const {getAllByText, getByText} = render(
     <Image
       image={img}
+      client={"test"}
       formats={[]}
       onCreateVariant={jest.fn}
       onDeleteVariant={jest.fn}
@@ -22,4 +23,6 @@ test('renders Image', () => {
     />)
   const arr = getAllByText(/some text/)
   expect(arr[0]).toBeInTheDocument()
+  const needle = getByText(/No Variant available/)
+  expect(needle).toBeInTheDocument()
 })

--- a/src/components/ImageCard.js
+++ b/src/components/ImageCard.js
@@ -25,9 +25,15 @@ const ImageCard = (props) => {
     }
   }
 
+  const variantMap = {}
+  img.variants.forEach(v => {
+    variantMap[v.client] = v
+  })
+  const clients = Object.keys(variantMap).filter(c => c !== '_internal')
+
   return(
     <div className='card bg-dark shadow'
-        onClick={ () => { setIsVisible(!isVisible)}}>
+         onClick={ () => { setIsVisible(!isVisible)}}>
 
       <img src={extractVersionUrl(props.version)} alt={img.alt} className='card-img-top' />
 
@@ -37,20 +43,21 @@ const ImageCard = (props) => {
           <p className='card-text'>
             <small>
               { img.category } <br />
-              &copy; {img.copyright} <br />
-              { img.url }
+    &copy; {img.copyright} <br />
+    { img.url }<br/>
+    Used by: { clients.join(", ") }
             </small>
           </p>
           <button onClick={ () => props.onShow(img)}
-            className='btn btn-sm btn-outline-primary btn-block'>
+                  className='btn btn-sm btn-outline-primary btn-block'>
             Show
           </button>
           <button onClick={ () => props.onEdit(img)}
-            className='btn btn-sm btn-outline-warning btn-block'>
+                  className='btn btn-sm btn-outline-warning btn-block'>
             Edit
           </button>
           <button onClick={ () => props.onDelete(img.id) }
-            className='btn btn-sm btn-outline-danger btn-block'>
+                  className='btn btn-sm btn-outline-danger btn-block'>
             Delete
           </button>
         </div>

--- a/src/components/VariantList.js
+++ b/src/components/VariantList.js
@@ -11,27 +11,23 @@ const VariantList = (props) => {
   }
 
   const rows = props.variants.map((v, key) => {
-    if (v.client !== 'image_library') {
-      return(
-        <tr key={key}>
-          <td>{v.id}</td>
-          <td>{v.client}</td>
-          <td>{v.name}</td>
-          <td className='text-nowrap'>{v.width}x{v.height}</td>
-          <td className='text-nowrap'><a href={v.url} target='_blank' rel='noopener noreferrer'>{v.url}</a></td>
-          <td className='text-nowrap text-right'>
-            <button className='btn btn-sm btn-outline-info'
-                    onClick={() => copyUrl(v.url)} >
-              Copy 2 Clipboard
-            </button>&nbsp;
-            <button className='btn btn-sm btn-outline-danger' onClick={() => props.onDeleteVariant(v)}>
-              Delete
-            </button>
-          </td>
-        </tr>
-      )
-    }
-    return ""
+    return(
+      <tr key={key}>
+        <td>{v.id}</td>
+        <td>{v.name}</td>
+        <td className='text-nowrap'>{v.width}x{v.height}</td>
+        <td className='text-nowrap'><a href={v.url} target='_blank' rel='noopener noreferrer'>{v.url}</a></td>
+        <td className='text-nowrap text-right'>
+          <button className='btn btn-sm btn-outline-info'
+                  onClick={() => copyUrl(v.url)} >
+            Copy 2 Clipboard
+          </button>&nbsp;
+      <button className='btn btn-sm btn-outline-danger' onClick={() => props.onDeleteVariant(v)}>
+        Delete
+      </button>
+        </td>
+      </tr>
+    )
   })
 
   return(

--- a/src/components/VariantList.js
+++ b/src/components/VariantList.js
@@ -11,16 +11,17 @@ const VariantList = (props) => {
   }
 
   const rows = props.variants.map((v, key) => {
-    if (v.name !== 'preview') {
+    if (v.client !== 'image_library') {
       return(
         <tr key={key}>
           <td>{v.id}</td>
+          <td>{v.client}</td>
           <td>{v.name}</td>
           <td className='text-nowrap'>{v.width}x{v.height}</td>
           <td className='text-nowrap'><a href={v.url} target='_blank' rel='noopener noreferrer'>{v.url}</a></td>
           <td className='text-nowrap text-right'>
             <button className='btn btn-sm btn-outline-info'
-              onClick={() => copyUrl(v.url)} >
+                    onClick={() => copyUrl(v.url)} >
               Copy 2 Clipboard
             </button>&nbsp;
             <button className='btn btn-sm btn-outline-danger' onClick={() => props.onDeleteVariant(v)}>
@@ -33,35 +34,25 @@ const VariantList = (props) => {
     return ""
   })
 
-
-
-  if (props.variants.length < 2) {
-    return(
-      <React.Fragment>
-        <p>None available</p>
-      </React.Fragment>
-    )
-  } else {
-    return(
-      <div className='table-responsive'>
-        <table className='table table-dark table-hover table-striped table-sm'>
-          <thead>
-            <tr>
-              <th>#</th>
-              <th>Name</th>
-              <th>Dimension</th>
-              <th>Url</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows}
-          </tbody>
-        </table>
-        <ToastContainer />
-      </div>
-    )
-  }
+  return(
+    <div className='table-responsive'>
+      <table className='table table-dark table-hover table-striped table-sm'>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Name</th>
+            <th>Dimension</th>
+            <th>Url</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows}
+        </tbody>
+      </table>
+      <ToastContainer />
+    </div>
+  )
 }
 
 VariantList.propTypes = {

--- a/src/components/VariantList.test.js
+++ b/src/components/VariantList.test.js
@@ -4,7 +4,7 @@ import VariantList from './VariantList'
 
 
 test('renders VariantList', () => {
-  const {getByText} = render(<VariantList variants={[]} />)
-  const needle = getByText(/None available/)
+  const {getByText} = render(<VariantList variants={[{ name: 'my_variant' }]} />)
+  const needle = getByText(/my_variant/)
   expect(needle).toBeInTheDocument()
 })


### PR DESCRIPTION
this also generates the preview variant as the hardcoded
'image_library' client and filters those
from Image#show variant list

Variants (and actions to create them) are shown
for the configured client prop, but badges
display other clients that have variants for the
currently shown image.

NOTE: we do not filter the list of images by
client, i.e. all clients can see all images
regardless of how/where they were uploaded

closes #7

![image](https://user-images.githubusercontent.com/28988/84510175-12abb880-acc5-11ea-8b40-c9ddc36a24c5.png)
